### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/HiberbeeTheme/HiberbeeTheme.csproj
+++ b/HiberbeeTheme/HiberbeeTheme.csproj
@@ -56,15 +56,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MessagePack">
-      <Version>3.1.3</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.13.40008" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.13.2126" />
     <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler" Version="17.11.35325.10" />
-    <PackageReference Include="System.Text.RegularExpressions">
-      <Version>4.3.1</Version>
-    </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="icon.png">

--- a/HiberbeeTheme/HiberbeeTheme.csproj
+++ b/HiberbeeTheme/HiberbeeTheme.csproj
@@ -56,9 +56,15 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365" />
-    <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler" Version="17.0.31902.203" />
+    <PackageReference Include="MessagePack">
+      <Version>3.1.3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.13.40008" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.13.2126" />
+    <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler" Version="17.11.35325.10" />
+    <PackageReference Include="System.Text.RegularExpressions">
+      <Version>4.3.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="icon.png">


### PR DESCRIPTION
I have a extension in my visual studio which notifies me of outdated and vulnerable dependencies. It notified me of an update to the SDK, and 3 vulnerable transitive packages. 
I updated the **_Microsoft.VisualStudio.SDK_**, which fixed 1 vulnerable package notification. Then turned **_MessagePack_** and **_System.Text.RegularExpressions_** into local packages to update them to the latest version, which fixed the last 2 vulnerable package notifications. 
I don't know if you need, or want this, but I am hoping it helps. Thank you for the great theme.